### PR TITLE
Fix some setup related issues

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ Installation
 
     urlpatterns = [
         ...
-        url(r'^api/', include('djangocms_rest_api.urls')),
+        url(r'^api/', include('djangocms_rest_api.urls', namespace='api')),
         ...
     ]
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,8 @@
 # -*- coding: utf-8 -*-
 import os
 import re
-import sys
+from setuptools import find_packages
+
 
 try:
     from setuptools import setup
@@ -24,14 +25,14 @@ version = get_version('djangocms_rest_api', '__init__.py')
 setup(
     name='djangocms-rest-api',
     version=version,
-    packages=['djangocms_rest_api', ],
+    packages=find_packages(),
     description='API for django cms.',
     long_description=open('README.rst').read(),
     author='SteelKiwi Development, Divio',
     author_email='getmansky@steelkiwi.com',
     include_package_data=True,
     install_requires=[
-        'djangorestframework==3.4.0',
+        'djangorestframework>=3.4,<3.5',
     ],
     license='MIT',
     url='https://github.com/divio/djangocms-rest-api',


### PR DESCRIPTION
Setup is missing packages, namely, views and serializers. We could add them in the list, or allow find_packages to take care of this for us. With this change, one may pip install directly from git, and/or we could add this to pypi. Also - the example may now include a requirement of this very library :).

Changing install_requires to allow for patch releases of django rest framework. Patch releases should not be api-breaking, and avoids some annoyances when relied-upon libraries pin to old versions.

The documentation is missing what I would think everyone would want by default: the api namespace (default). Otherwise we get exceptions :)
